### PR TITLE
Fix link to plausible script

### DIFF
--- a/julia-intro/docs/_config.yml
+++ b/julia-intro/docs/_config.yml
@@ -38,4 +38,4 @@ html:
 sphinx:
   config:
     html_extra_path: ["assets"]
-    html_js_files: [ ['https://plausible.io/js/script.js', {'defer': 'defer', 'data-domain': 'hepsoftwarefoundation.org'}] ]
+    html_js_files: [ ['https://views.scientific-python.org/js/script.js', {'defer': 'defer', 'data-domain': 'hepsoftwarefoundation.org'}] ]


### PR DESCRIPTION
We might need to use the script from `view.scientific-python.org` rather than the default one from plausible. At least I'm currently not seeing any data from this page and this seems to be the only difference.