### PR TITLE
Add HSF training badge and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![HSF Training Center](https://img.shields.io/badge/HSF%20Training%20Center-browse-ff69b4)](https://hepsoftwarefoundation.org/training/curriculum.html)
+
 # JuliaHEP-2023
 Materials for the JuliaHEP 2023 Workshop.
 
@@ -7,6 +9,6 @@ Follow the tutorial with Binder:
 [![Binder](https://binderhub.ssl-hep.org/badge_logo.svg)](https://binderhub.ssl-hep.org/v2/gh/JuliaHEP/JuliaHEP-2023/HEAD?labpath=julia-intro%2Fdocs%2Fjulia-intro-intro.ipynb)
 
 - - -
-When not taken from other sources (which has its own Copyright and License), this material is:
-Copyright © 2023 the authors / contributors
+When not taken from other sources (with its own Copyright and License), this material is:
+Copyright © 2023 CERN and the authors / contributors
 Licensed under CC-BY-4.0

--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ Follow the tutorial with Binder:
 
 - - -
 When not taken from other sources (with its own Copyright and License), this material is:
-Copyright © 2023 CERN and the authors / contributors
-Licensed under CC-BY-4.0
+
+Copyright © 2023 CERN and the authors / contributors.
+
+Licensed under [CC-BY-4.0](./LICENSE).

--- a/julia-intro/docs/intro.md
+++ b/julia-intro/docs/intro.md
@@ -2,7 +2,9 @@
 
 This is a short introductory tutorial for the [Julia](https://julialang.org) programming language.
 
-This tutorial is supported by the [HSF JuliaHEP](https://hepsoftwarefoundation.org/workinggroups/juliahep.html) team.
+This tutorial is supported by the [HSF JuliaHEP](https://hepsoftwarefoundation.org/workinggroups/juliahep.html) team and currently it is maintained by [Sam Skipsey](https://github.com/aoanla) and [Graeme Stewart](https://github.com/graeme-a-stewart).
+
+This material is part of the [HSF Software Training Centre](https://hepsoftwarefoundation.org/training/curriculum.html), a series of training modules that serves HEP newcomers in learning the software skills they need as the enter the field and promotes best practice in writing software.
 
 <p align="center">
 <img src="hsf_logo_angled.png" alt="HEP Software Foundation Logo..."/>


### PR DESCRIPTION
Improve integration with HSF Training Centre

Add training badge in GitHub README
Format (c) and license better on README
Add Sam and Graeme as current maintainers on front page
Add link to HSF Training Centre to introductory page to front page

Closes #31 